### PR TITLE
Add Raspberry Pi clue clients and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
+# Jigsaw Control
 
+Modern control surface for the Jigsaw escape room network. The application exposes a FastAPI backend with a responsive, dark-mode web UI to control room timers, send video or text clues, and keep track of puzzle status across Raspberry Pi devices.
+
+## Features
+
+- Real-time WebSocket updates for timer, puzzle status, and activity log.
+- Timer controls with quick adjustments and manual set input.
+- Per-room puzzle dashboard with buttons to trigger video clues, toggle solved state, and adjust hint counters.
+- Text clue sender with device selectors to target individual Raspberry Pis.
+- MQTT integration with configurable topics and broker host.
+
+## Project layout
+
+```
+app/
+├── config.py          # Environment configuration & MQTT topic helpers
+├── core/
+│   ├── state.py       # In-memory state store and timers
+│   ├── timer.py       # Countdown timer helper
+│   └── websocket_manager.py
+├── data.py            # Room/puzzle catalogue and default targets
+├── main.py            # FastAPI application factory & routes
+├── models/
+│   └── game.py        # Game metadata and state dataclasses
+├── services/
+│   └── mqtt_service.py
+├── static/
+│   ├── app.js         # Front-end logic
+│   └── style.css      # Dark glassmorphism theme
+└── templates/
+    └── index.html     # UI shell
+```
+
+## Running locally
+
+Install dependencies and start the server.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+uvicorn app.main:create_app --reload
+```
+
+Open http://localhost:8000 in a browser. Update `app/config.py` if your MQTT broker host or topic structure differs.
+
+## Deployment on Raspberry Pi
+
+### Control interface (Hol Intrare Pi)
+
+1. Copy the repository to the Hol Intrare Pi (the one hosting the web app).
+2. Create a Python virtual environment and install dependencies as above.
+3. Configure a systemd service pointing to `uvicorn app.main:create_app` to keep the control room available on boot.
+
+### Clue players (Boiler Room / Hol Intrare / Last Room Pis)
+
+Each Pi that plays videos or shows text clues runs the lightweight client in `pi_clients/`:
+
+```bash
+python -m pi_clients.run_client boilerroom   # or holintrare / lastroom
+```
+
+The client connects to the MQTT broker configured in `app/config.py`, listens for `/video/play` and `/text/send` topics under its prefix, launches VLC fullscreen for videos, and displays text messages on a dark overlay. See `pi_clients/README.md` for detailed setup steps and customization notes.
+
+The UI is designed for large touch displays with dim light conditions and should render crisply on Chromium-based kiosk browsers.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Jigsaw Control application package."""

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pydantic import BaseModel, Field
+
+
+class MqttTopicMap(BaseModel):
+    video: str = Field(default="video/play")
+    text: str = Field(default="text/send")
+    status: str = Field(default="status/update")
+
+
+class DeviceConfig(BaseModel):
+    name: str
+    label: str
+    mqtt_prefix: str
+    topics: MqttTopicMap = Field(default_factory=MqttTopicMap)
+
+    def topic_for(self, kind: str) -> str:
+        topic = getattr(self.topics, kind)
+        if topic.startswith("/"):
+            return f"{self.mqtt_prefix}{topic}"
+        return f"{self.mqtt_prefix}/{topic}".rstrip("/")
+
+
+class Settings(BaseModel):
+    mqtt_host: str = Field(default="192.168.1.217", description="MQTT broker host")
+    mqtt_port: int = Field(default=1883, description="MQTT broker port")
+    mqtt_username: str | None = Field(default=None, description="Optional MQTT username")
+    mqtt_password: str | None = Field(default=None, description="Optional MQTT password")
+    allow_cross_origin: bool = Field(default=True, description="Enable CORS for the UI")
+
+    devices: dict[str, DeviceConfig] = Field(
+        default_factory=lambda: {
+            "boilerroom": DeviceConfig(name="boilerroom", label="Boiler Room", mqtt_prefix="boiler"),
+            "lastroom": DeviceConfig(name="lastroom", label="Last Room", mqtt_prefix="last"),
+            "holintrare": DeviceConfig(name="holintrare", label="Hol Intrare", mqtt_prefix="hall"),
+        }
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, Iterable
+
+from .timer import CountdownTimer, TimerSnapshot
+from .websocket_manager import WebSocketManager
+from ..data import ROOM_GROUPS, all_games
+from ..models.game import GameState
+
+
+class AppState:
+    def __init__(self, ws_manager: WebSocketManager) -> None:
+        self.ws = ws_manager
+        self.timer = CountdownTimer(on_tick=self._on_timer_tick)
+        self._games: Dict[str, GameState] = {game.id: GameState(game=game) for game in all_games()}
+        self._log: list[dict[str, Any]] = []
+        self._lock = asyncio.Lock()
+
+    async def full_state(self) -> dict[str, Any]:
+        async with self._lock:
+            puzzles = [state.to_dict for state in self._games.values()]
+            log = list(self._log)
+        timer_snapshot = self.timer.snapshot()
+        return {
+            "timer": timer_snapshot.formatted,
+            "timer_running": timer_snapshot.running,
+            "puzzles": puzzles,
+            "log": log,
+            "rooms": {
+                key: {"label": data["label"], "targets": data["targets"]}
+                for key, data in ROOM_GROUPS.items()
+            },
+        }
+
+    async def mark_solved(self, puzzle_id: str, solved: bool) -> dict[str, Any]:
+        async with self._lock:
+            state = self._games[puzzle_id]
+            state.solved = solved
+            state.solve_timestamp = time.time() if solved else None
+            payload = state.to_dict
+        await self.ws.broadcast({"type": "puzzle", "data": payload})
+        self.add_log(f"Puzzle {payload['label']} marked {'solved' if solved else 'unsolved'}")
+        return payload
+
+    async def increment_hint(self, puzzle_id: str, delta: int = 1) -> dict[str, Any]:
+        async with self._lock:
+            state = self._games[puzzle_id]
+            state.hints_used = max(0, state.hints_used + int(delta))
+            payload = state.to_dict
+        await self.ws.broadcast({"type": "puzzle", "data": payload})
+        self.add_log(f"Hints for {payload['label']} set to {payload['hints_used']}")
+        return payload
+
+    async def set_hints(self, puzzle_id: str, value: int) -> dict[str, Any]:
+        async with self._lock:
+            state = self._games[puzzle_id]
+            state.hints_used = max(0, int(value))
+            payload = state.to_dict
+        await self.ws.broadcast({"type": "puzzle", "data": payload})
+        self.add_log(f"Hints for {payload['label']} set to {payload['hints_used']}")
+        return payload
+
+    def add_log(self, message: str, *, kind: str = "info") -> None:
+        entry = {"ts": time.time(), "message": message, "kind": kind}
+        self._log.append(entry)
+        self._log = self._log[-400:]
+        asyncio.create_task(self.ws.broadcast({"type": "log", "data": entry}))
+
+    def game_state(self, puzzle_id: str) -> GameState:
+        return self._games[puzzle_id]
+
+    async def timer_action(self, action: str, value: int | None = None) -> TimerSnapshot:
+        action = action.lower()
+        if action == "start":
+            snapshot = await self.timer.start()
+            self.add_log("Timer started")
+        elif action == "pause":
+            snapshot = await self.timer.pause()
+            self.add_log("Timer paused")
+        elif action == "reset":
+            seconds = value or 0
+            snapshot = await self.timer.reset(seconds)
+            self.add_log(f"Timer reset to {snapshot.formatted}")
+        elif action == "set":
+            if value is None:
+                raise ValueError("Set action requires a value")
+            snapshot = await self.timer.set_seconds(value)
+            self.add_log(f"Timer set to {snapshot.formatted}")
+        elif action == "add":
+            if value is None:
+                raise ValueError("Add action requires a value")
+            snapshot = await self.timer.add_seconds(value)
+            sign = "+" if value >= 0 else ""
+            self.add_log(f"Timer adjusted by {sign}{value}s → {snapshot.formatted}")
+        else:
+            raise ValueError(f"Unknown timer action: {action}")
+        return snapshot
+
+    async def timer_tick_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(1)
+                snapshot = await self.timer.tick()
+                if snapshot.running and snapshot.seconds == 0:
+                    self.add_log("Timer completed", kind="success")
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            return
+
+    def _on_timer_tick(self, snapshot: TimerSnapshot) -> None:
+        asyncio.create_task(self.ws.broadcast({"type": "timer", "data": {
+            "formatted": snapshot.formatted,
+            "running": snapshot.running,
+        }}))
+
+    def puzzles_for_room(self, room_key: str) -> Iterable[dict[str, Any]]:
+        return [state.to_dict for state in self._games.values() if state.game.room.lower().replace(" ", "") == room_key]

--- a/app/core/timer.py
+++ b/app/core/timer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class TimerSnapshot:
+    seconds: int
+    running: bool
+
+    @property
+    def formatted(self) -> str:
+        total = max(0, self.seconds)
+        hours, remainder = divmod(total, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+class CountdownTimer:
+    """Lightweight countdown timer with async tick notifications."""
+
+    def __init__(self, *, on_tick: Callable[[TimerSnapshot], None] | None = None):
+        self._remaining_seconds: int = 0
+        self._running: bool = False
+        self._last_start_monotonic: float | None = None
+        self._lock = asyncio.Lock()
+        self._on_tick = on_tick
+        self._last_broadcast_seconds: int | None = None
+        self._last_broadcast_running: bool | None = None
+
+    async def reset(self, seconds: int = 0) -> TimerSnapshot:
+        async with self._lock:
+            self._remaining_seconds = max(0, int(seconds))
+            self._running = False
+            self._last_start_monotonic = None
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    async def set_seconds(self, seconds: int) -> TimerSnapshot:
+        async with self._lock:
+            self._remaining_seconds = max(0, int(seconds))
+            if self._running:
+                self._last_start_monotonic = time.monotonic()
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    async def add_seconds(self, delta: int) -> TimerSnapshot:
+        async with self._lock:
+            if self._running:
+                self._sync_locked()
+            self._remaining_seconds = max(0, self._remaining_seconds + int(delta))
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    async def start(self) -> TimerSnapshot:
+        async with self._lock:
+            if self._remaining_seconds <= 0:
+                self._remaining_seconds = 0
+                self._running = False
+            elif not self._running:
+                self._running = True
+                self._last_start_monotonic = time.monotonic()
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    async def pause(self) -> TimerSnapshot:
+        async with self._lock:
+            if self._running:
+                self._sync_locked()
+                self._running = False
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    async def tick(self) -> TimerSnapshot:
+        async with self._lock:
+            if self._running:
+                self._sync_locked()
+                if self._remaining_seconds <= 0:
+                    self._remaining_seconds = 0
+                    self._running = False
+            snapshot = self._snapshot()
+        self._emit(snapshot)
+        return snapshot
+
+    def _sync_locked(self) -> None:
+        if not self._running or self._last_start_monotonic is None:
+            return
+        elapsed = int(time.monotonic() - self._last_start_monotonic)
+        if elapsed <= 0:
+            return
+        self._remaining_seconds = max(0, self._remaining_seconds - elapsed)
+        self._last_start_monotonic = time.monotonic()
+
+    def _snapshot(self) -> TimerSnapshot:
+        if self._running and self._last_start_monotonic is not None:
+            elapsed = int(time.monotonic() - self._last_start_monotonic)
+            remaining = max(0, self._remaining_seconds - elapsed)
+        else:
+            remaining = max(0, self._remaining_seconds)
+        return TimerSnapshot(seconds=remaining, running=self._running and remaining > 0)
+
+    def _emit(self, snapshot: TimerSnapshot) -> None:
+        if not self._on_tick:
+            return
+        if (
+            self._last_broadcast_seconds == snapshot.seconds
+            and self._last_broadcast_running == snapshot.running
+        ):
+            return
+        self._on_tick(snapshot)
+        self._last_broadcast_seconds = snapshot.seconds
+        self._last_broadcast_running = snapshot.running
+
+    def snapshot(self) -> TimerSnapshot:
+        return self._snapshot()

--- a/app/core/websocket_manager.py
+++ b/app/core/websocket_manager.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from fastapi import WebSocket
+
+
+class WebSocketManager:
+    def __init__(self) -> None:
+        self._connections: set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._connections.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._connections.discard(websocket)
+
+    async def broadcast(self, message: dict[str, Any]) -> None:
+        payload = json.dumps(message)
+        async with self._lock:
+            send_coros = [self._safe_send(ws, payload) for ws in list(self._connections)]
+        if send_coros:
+            await asyncio.gather(*send_coros, return_exceptions=True)
+
+    async def _safe_send(self, websocket: WebSocket, payload: str) -> None:
+        try:
+            await websocket.send_text(payload)
+        except Exception:
+            await self.disconnect(websocket)

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Dict, List
+
+from .models.game import Game
+
+
+def _game(game_id: str, label: str, room: str, video: str, targets: Iterable[str]):
+    return Game(id=game_id, label=label, room=room, video=video, default_targets=list(targets))
+
+
+ROOM_GROUPS: Dict[str, dict] = {
+    "boilerroom": {
+        "label": "Boiler Room",
+        "targets": ["boilerroom"],
+        "games": [
+            _game("ALL_BOILER", "All — Boiler Intro", "Boiler Room", "ALL_BOILER.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_DEGETE", "All — Fingers", "Boiler Room", "ALL_DEGETE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_HAPPY", "All — Happy", "Boiler Room", "ALL_HAPPY.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("BR_CARABINA", "Carabina", "Boiler Room", "BR_CARABINA.mp4", ["boilerroom"]),
+            _game("BR_DEBUG", "Debug", "Boiler Room", "BR_DEBUG.mp4", ["boilerroom"]),
+            _game("BR_LUMINA", "Lumina", "Boiler Room", "BR_LUMINA.mp4", ["boilerroom"]),
+            _game("BR_PATRATELE", "Pătrățele", "Boiler Room", "BR_PATRATELE.mp4", ["boilerroom"]),
+            _game("BR_POARTA", "Poartă", "Boiler Room", "BR_POARTA.mp4", ["boilerroom"]),
+            _game("BR_X", "X", "Boiler Room", "BR_X.mp4", ["boilerroom"]),
+        ],
+    },
+    "smallroom": {
+        "label": "Small Room",
+        "targets": ["boilerroom"],
+        "games": [
+            _game("SR_BIDEU", "Bideu", "Small Room", "SR_BIDEU.mp4", ["boilerroom"]),
+            _game("SR_IMBUS", "Imbus", "Small Room", "SR_IMBUS.mp4", ["boilerroom"]),
+            _game("SR_LUMINA", "Lumina", "Small Room", "SR_LUMINA.mp4", ["boilerroom"]),
+            _game("SR_PUZZLE", "Puzzle", "Small Room", "SR_PUZZLE.mp4", ["boilerroom"]),
+            _game("SR_SAW", "Saw", "Small Room", "SR_SAW.mp4", ["boilerroom"]),
+        ],
+    },
+    "hallroom": {
+        "label": "Hall Room",
+        "targets": ["holintrare"],
+        "games": [
+            _game("ALL_BUCATARIE", "All — Bucătărie", "Hall Room", "ALL_BUCATARIE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_INTALNIRE", "All — Întâlnire", "Hall Room", "ALL_INTALNIRE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("HR_CARABINA", "Carabina", "Hall Room", "HR_CARABINA.mp4", ["holintrare"]),
+            _game("HR_JAWS", "Jaws", "Hall Room", "HR_JAWS.mp4", ["holintrare"]),
+            _game("HR_KEY_DOOR", "Key Door", "Hall Room", "HR_KEY_DOOR.mp4", ["holintrare"]),
+            _game("HR_LUMINA", "Lumina", "Hall Room", "HR_LUMINA.mp4", ["holintrare"]),
+        ],
+    },
+    "holintrare": {
+        "label": "Hol Intrare",
+        "targets": ["holintrare"],
+        "games": [
+            _game("ALL_BUTOANE", "All — Butoane", "Hol Intrare", "ALL_BUTOANE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_CHEIE_BULINA", "All — Cheie Bulina", "Hol Intrare", "ALL_CHEIE_BULINA.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_DECODOR", "All — Decodor", "Hol Intrare", "ALL_DECODOR.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_LEMN", "All — Lemn", "Hol Intrare", "ALL_LEMN.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_SFORI", "All — Sfori", "Hol Intrare", "ALL_SFORI.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_VIDEOPLAYER", "All — Videoplayer", "Hol Intrare", "ALL_VIDEOPLAYER.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_ZAVOR", "All — Zăvor", "Hol Intrare", "ALL_ZAVOR.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("HI_LOCO", "LoCo", "Hol Intrare", "HI_LOCO.mp4", ["holintrare"]),
+            _game("HI_LUMINA", "Lumina", "Hol Intrare", "HI_LUMINA.mp4", ["holintrare"]),
+            _game("HI_SAGETI", "Săgeți", "Hol Intrare", "HI_SAGETI.mp4", ["holintrare"]),
+        ],
+    },
+    "jigsawroom": {
+        "label": "Jigsaw Room",
+        "targets": ["lastroom"],
+        "games": [
+            _game("ALL_ANTIDOT", "All — Antidot", "Jigsaw Room", "ALL_ANTIDOT.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_DIRECTII", "All — Direcții", "Jigsaw Room", "ALL_DIRECTII.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_FEAR", "All — Fear", "Jigsaw Room", "ALL_FEAR.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_HELP", "All — Help", "Jigsaw Room", "ALL_HELP.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_LACAT_GALBEN", "All — Lacăt Galben", "Jigsaw Room", "ALL_LACAT_GALBEN.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_LACAT_VERDE", "All — Lacăt Verde", "Jigsaw Room", "ALL_LACAT_VERDE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_LEMNE_JIGSAW", "All — Lemne", "Jigsaw Room", "ALL_LEMNE_JIGSAW.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_ORGANE", "All — Organe", "Jigsaw Room", "ALL_ORGANE.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_SEIF", "All — Seif", "Jigsaw Room", "ALL_SEIF.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_TEAVA", "All — Țeavă", "Jigsaw Room", "ALL_TEAVA.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_UV", "All — UV", "Jigsaw Room", "ALL_UV.mp4", ["boilerroom", "lastroom", "holintrare"]),
+        ],
+    },
+    "lastroom": {
+        "label": "Last Room",
+        "targets": ["lastroom"],
+        "games": [
+            _game("ALL_CUTIE_BILA", "All — Cutie Bilă", "Last Room", "ALL_CUTIE_BILA.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_FEED", "All — Feed", "Last Room", "ALL_FEED.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_LILIAC", "All — Liliac", "Last Room", "ALL_LILIAC.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("ALL_TREFLA", "All — Trefla", "Last Room", "ALL_TREFLA.mp4", ["boilerroom", "lastroom", "holintrare"]),
+            _game("LR_38", "38", "Last Room", "LR_38.mp4", ["lastroom"]),
+            _game("LR_ABCDE", "ABCDE", "Last Room", "LR_ABCDE.mp4", ["lastroom"]),
+            _game("LR_ARROWS", "Arrows", "Last Room", "LR_ARROWS.mp4", ["lastroom"]),
+            _game("LR_CARABINA", "Carabina", "Last Room", "LR_CARABINA.mp4", ["lastroom"]),
+            _game("LR_CODE", "Code", "Last Room", "LR_CODE.mp4", ["lastroom"]),
+            _game("LR_GRAVITY", "Gravity", "Last Room", "LR_GRAVITY.mp4", ["lastroom"]),
+            _game("LR_LUMINA", "Lumina", "Last Room", "LR_LUMINA.mp4", ["lastroom"]),
+        ],
+    },
+}
+
+
+def all_games() -> List[Game]:
+    games: List[Game] = []
+    for group in ROOM_GROUPS.values():
+        games.extend(group["games"])
+    return games

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel, Field, model_validator
+
+from .config import DeviceConfig, Settings, get_settings
+from .core.state import AppState
+from .core.websocket_manager import WebSocketManager
+from .services.mqtt_service import MqttService
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+class TimerControlRequest(BaseModel):
+    action: Literal["start", "pause", "reset", "set", "add"]
+    value: int | None = Field(default=None, description="Value in seconds")
+
+
+class SolveRequest(BaseModel):
+    solved: bool
+
+
+class HintRequest(BaseModel):
+    delta: int | None = Field(default=None, description="Increment hints by delta")
+    value: int | None = Field(default=None, description="Override hints count")
+
+    @model_validator(mode="after")
+    def _validate(cls, values: "HintRequest") -> "HintRequest":  # noqa: N805
+        if values.delta is None and values.value is None:
+            raise ValueError("Either delta or value must be provided")
+        if values.delta is not None and values.value is not None:
+            raise ValueError("Provide either delta or value, not both")
+        return values
+
+
+class VideoRequest(BaseModel):
+    game_id: str
+    targets: list[str] | None = Field(default=None, description="Target device keys")
+
+
+class MessageRequest(BaseModel):
+    text: str = Field(..., min_length=1, description="Message to send")
+    targets: list[str] = Field(default_factory=list, description="Target device keys")
+
+
+class ApiContext(BaseModel):
+    settings: Settings
+    state: AppState
+    mqtt: MqttService
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    settings = settings or get_settings()
+    ws_manager = WebSocketManager()
+    state = AppState(ws_manager)
+    mqtt = MqttService(settings)
+
+    app = FastAPI(title="Jigsaw Control", version="0.1.0")
+
+    if settings.allow_cross_origin:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    app.state.ws_manager = ws_manager
+    app.state.app_state = state
+    app.state.mqtt = mqtt
+    app.state.timer_task = None
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - lifecycle
+        mqtt.start()
+        app.state.timer_task = asyncio.create_task(state.timer_tick_loop())
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:  # pragma: no cover - lifecycle
+        if app.state.timer_task:
+            app.state.timer_task.cancel()
+        mqtt.stop()
+
+    async def get_context() -> ApiContext:
+        return ApiContext(settings=settings, state=state, mqtt=mqtt)
+
+    @app.get("/", response_class=FileResponse)
+    async def index() -> FileResponse:
+        return FileResponse(BASE_DIR / "templates" / "index.html")
+
+    @app.get("/api/state")
+    async def get_state(ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        data = await ctx.state.full_state()
+        data["devices"] = _devices_summary(settings)
+        data["mqtt_host"] = settings.mqtt_host
+        return JSONResponse(data)
+
+    @app.post("/api/timer/control")
+    async def timer_control(payload: TimerControlRequest, ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        value = payload.value
+        if payload.action in {"set", "add"} and value is None:
+            raise HTTPException(status_code=400, detail="value is required for this action")
+        if payload.action == "reset":
+            value = value or 0
+        snapshot = await ctx.state.timer_action(payload.action, value)
+        return JSONResponse({"timer": snapshot.formatted, "running": snapshot.running})
+
+    @app.post("/api/puzzles/{puzzle_id}/solve")
+    async def solve_puzzle(puzzle_id: str, payload: SolveRequest, ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        try:
+            data = await ctx.state.mark_solved(puzzle_id, payload.solved)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Puzzle not found") from None
+        return JSONResponse(data)
+
+    @app.post("/api/puzzles/{puzzle_id}/hints")
+    async def update_hints(puzzle_id: str, payload: HintRequest, ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        try:
+            if payload.value is not None:
+                data = await ctx.state.set_hints(puzzle_id, payload.value)
+            else:
+                delta = payload.delta or 0
+                if delta == 0:
+                    raise HTTPException(status_code=400, detail="delta cannot be zero")
+                data = await ctx.state.increment_hint(puzzle_id, delta)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Puzzle not found") from None
+        return JSONResponse(data)
+
+    @app.post("/api/video")
+    async def play_video(payload: VideoRequest, ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        try:
+            game_state = ctx.state.game_state(payload.game_id)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Game not found") from None
+
+        targets = payload.targets or list(game_state.game.default_targets)
+        devices = _resolve_devices(settings, targets)
+        if not devices:
+            raise HTTPException(status_code=400, detail="No valid targets provided")
+
+        ctx.mqtt.publish_multi(devices, "video", game_state.game.video)
+        ctx.state.add_log(
+            f"Video {game_state.game.video} sent to {', '.join(device.label for device in devices)}",
+            kind="action",
+        )
+        return JSONResponse({"status": "ok"})
+
+    @app.post("/api/messages")
+    async def send_message(payload: MessageRequest, ctx: ApiContext = Depends(get_context)) -> JSONResponse:
+        targets = payload.targets or list(settings.devices.keys())
+        devices = _resolve_devices(settings, targets)
+        if not devices:
+            raise HTTPException(status_code=400, detail="No valid targets provided")
+
+        ctx.mqtt.publish_multi(devices, "text", payload.text)
+        ctx.state.add_log(
+            f"Message sent to {', '.join(device.label for device in devices)}: {payload.text}",
+            kind="message",
+        )
+        return JSONResponse({"status": "ok"})
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(websocket: WebSocket, ctx: ApiContext = Depends(get_context)) -> None:
+        await app.state.ws_manager.connect(websocket)
+        try:
+            full_state = await ctx.state.full_state()
+            full_state["devices"] = _devices_summary(settings)
+            full_state["mqtt_host"] = settings.mqtt_host
+            await websocket.send_json({"type": "state", "data": full_state})
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            await app.state.ws_manager.disconnect(websocket)
+
+    return app
+
+
+def _resolve_devices(settings: Settings, keys: list[str]) -> list[DeviceConfig]:
+    devices: list[DeviceConfig] = []
+    for key in keys:
+        device = settings.devices.get(key)
+        if device:
+            devices.append(device)
+    return devices
+
+
+def _devices_summary(settings: Settings) -> dict[str, dict[str, str]]:
+    return {key: {"label": device.label} for key, device in settings.devices.items()}

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass(slots=True)
+class Game:
+    id: str
+    label: str
+    room: str
+    video: str
+    default_targets: Sequence[str]
+    description: str | None = None
+
+
+@dataclass(slots=True)
+class GameState:
+    game: Game
+    solved: bool = False
+    hints_used: int = 0
+    solve_timestamp: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.game.id,
+            "label": self.game.label,
+            "room": self.game.room,
+            "room_key": self.game.room.lower().replace(" ", ""),
+            "video": self.game.video,
+            "targets": list(self.game.default_targets),
+            "solved": self.solved,
+            "hints_used": self.hints_used,
+            "solve_timestamp": self.solve_timestamp,
+            "notes": list(self.notes),
+        }

--- a/app/services/mqtt_service.py
+++ b/app/services/mqtt_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import paho.mqtt.client as mqtt
+
+from ..config import DeviceConfig, Settings, get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class MqttService:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._client = mqtt.Client()
+        if self.settings.mqtt_username and self.settings.mqtt_password:
+            self._client.username_pw_set(self.settings.mqtt_username, self.settings.mqtt_password)
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+
+    def start(self) -> None:
+        try:
+            self._client.connect(self.settings.mqtt_host, self.settings.mqtt_port, 60)
+            self._client.loop_start()
+        except Exception:  # pragma: no cover - network environment dependent
+            logger.exception("Failed to connect to MQTT broker")
+
+    def stop(self) -> None:
+        try:
+            self._client.loop_stop()
+            self._client.disconnect()
+        except Exception:  # pragma: no cover
+            logger.exception("Error stopping MQTT client")
+
+    def publish(self, device: DeviceConfig, kind: str, payload: str) -> None:
+        topic = device.topic_for(kind)
+        try:
+            self._client.publish(topic, payload)
+            logger.info("MQTT publish %s → %s", topic, payload)
+        except Exception:  # pragma: no cover
+            logger.exception("Failed to publish MQTT message")
+
+    def publish_multi(self, devices: Iterable[DeviceConfig], kind: str, payload: str) -> None:
+        for device in devices:
+            self.publish(device, kind, payload)
+
+    @staticmethod
+    def _on_connect(client: mqtt.Client, userdata, flags, rc):  # pragma: no cover - callback
+        if rc == 0:
+            logger.info("Connected to MQTT broker")
+        else:
+            logger.error("MQTT connection failed with code %s", rc)
+
+    @staticmethod
+    def _on_disconnect(client: mqtt.Client, userdata, rc):  # pragma: no cover - callback
+        logger.info("MQTT disconnected (%s)", rc)

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,387 @@
+const state = {
+  timer: '00:00:00',
+  running: false,
+  puzzles: {},
+  rooms: {},
+  devices: {},
+  log: [],
+};
+
+const timerDisplay = document.getElementById('timer-display');
+const timerStatus = document.getElementById('timer-status');
+const wsStatus = document.getElementById('ws-status');
+const mqttHost = document.getElementById('mqtt-host');
+const logStream = document.getElementById('log-stream');
+const roomsContainer = document.getElementById('rooms-container');
+const deviceCheckboxes = document.getElementById('device-checkboxes');
+
+async function postJSON(url, body) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json().catch(() => ({}));
+}
+
+function updateTimerDisplay(formatted, running) {
+  state.timer = formatted;
+  state.running = !!running;
+  timerDisplay.textContent = formatted;
+  timerStatus.textContent = running ? 'Running' : 'Paused';
+  timerStatus.classList.toggle('text-success', !!running);
+  timerStatus.classList.toggle('text-secondary', !running);
+}
+
+function renderDevices(devices) {
+  deviceCheckboxes.innerHTML = '';
+  Object.entries(devices).forEach(([key, info]) => {
+    const pill = document.createElement('label');
+    pill.className = 'device-pill';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.value = key;
+    input.checked = true;
+    pill.appendChild(input);
+
+    const span = document.createElement('span');
+    span.textContent = info.label || key;
+    pill.appendChild(span);
+
+    deviceCheckboxes.appendChild(pill);
+  });
+}
+
+function groupPuzzles() {
+  const grouped = {};
+  Object.values(state.puzzles).forEach((puzzle) => {
+    const key = puzzle.room_key;
+    if (!grouped[key]) {
+      grouped[key] = [];
+    }
+    grouped[key].push(puzzle);
+  });
+  return grouped;
+}
+
+function renderRooms() {
+  roomsContainer.innerHTML = '';
+  const grouped = groupPuzzles();
+
+  Object.entries(state.rooms).forEach(([key, roomInfo]) => {
+    const puzzles = grouped[key] || [];
+    const card = document.createElement('div');
+    card.className = 'puzzle-card';
+
+    const header = document.createElement('div');
+    header.className = 'd-flex justify-content-between align-items-start gap-3';
+    const title = document.createElement('h3');
+    title.className = 'mb-0 text-accent';
+    title.textContent = roomInfo.label || key;
+    header.appendChild(title);
+
+    const targets = document.createElement('div');
+    targets.className = 'text-secondary small';
+    const targetLabels = (roomInfo.targets || [])
+      .map((t) => state.devices[t]?.label || t)
+      .join(', ');
+    targets.textContent = targetLabels ? `Targets: ${targetLabels}` : '';
+    header.appendChild(targets);
+    card.appendChild(header);
+
+    const table = document.createElement('table');
+    table.className = 'puzzle-table';
+    const tbody = document.createElement('tbody');
+
+    puzzles.forEach((puzzle) => {
+      const tr = document.createElement('tr');
+
+      const nameTd = document.createElement('td');
+      const name = document.createElement('div');
+      name.className = 'fw-semibold';
+      name.textContent = puzzle.label;
+      nameTd.appendChild(name);
+      const hintBadge = document.createElement('div');
+      hintBadge.className = 'badge-soft info mt-1 d-inline-flex align-items-center gap-2';
+      const hintIcon = document.createElement('span');
+      hintIcon.textContent = '💡';
+      hintBadge.appendChild(hintIcon);
+      const hintText = document.createElement('span');
+      hintText.textContent = `Hints: ${puzzle.hints_used}`;
+      hintBadge.appendChild(hintText);
+      nameTd.appendChild(hintBadge);
+      tr.appendChild(nameTd);
+
+      const statusTd = document.createElement('td');
+      const badge = document.createElement('span');
+      badge.className = `badge-soft ${puzzle.solved ? 'success' : 'danger'}`;
+      badge.textContent = puzzle.solved ? 'Solved' : 'Pending';
+      statusTd.appendChild(badge);
+      tr.appendChild(statusTd);
+
+      const actionsTd = document.createElement('td');
+      actionsTd.className = 'room-actions text-end';
+      const playBtn = document.createElement('button');
+      playBtn.className = 'btn btn-sm btn-outline-info me-2';
+      playBtn.textContent = 'Play clue';
+      playBtn.addEventListener('click', () => triggerVideo(puzzle.id));
+
+      const solvedBtn = document.createElement('button');
+      solvedBtn.className = `btn btn-sm ${puzzle.solved ? 'btn-success' : 'btn-outline-success'} me-2`;
+      solvedBtn.textContent = puzzle.solved ? 'Mark unsolved' : 'Mark solved';
+      solvedBtn.addEventListener('click', () => toggleSolved(puzzle));
+
+      const hintGroup = document.createElement('div');
+      hintGroup.className = 'btn-group btn-group-sm';
+      const hintMinus = document.createElement('button');
+      hintMinus.className = 'btn btn-outline-light';
+      hintMinus.textContent = '-';
+      hintMinus.addEventListener('click', () => adjustHints(puzzle, -1));
+      const hintPlus = document.createElement('button');
+      hintPlus.className = 'btn btn-outline-light';
+      hintPlus.textContent = '+';
+      hintPlus.addEventListener('click', () => adjustHints(puzzle, 1));
+      hintGroup.appendChild(hintMinus);
+      hintGroup.appendChild(hintPlus);
+
+      actionsTd.appendChild(playBtn);
+      actionsTd.appendChild(solvedBtn);
+      actionsTd.appendChild(hintGroup);
+      tr.appendChild(actionsTd);
+
+      tbody.appendChild(tr);
+    });
+
+    table.appendChild(tbody);
+    card.appendChild(table);
+    roomsContainer.appendChild(card);
+  });
+}
+
+function renderLog(entries) {
+  logStream.innerHTML = '';
+  entries.forEach((entry) => appendLog(entry, false));
+  logStream.scrollTop = logStream.scrollHeight;
+}
+
+function appendLog(entry, pushState = true) {
+  if (pushState) {
+    state.log.push(entry);
+    state.log = state.log.slice(-400);
+  }
+  const row = document.createElement('div');
+  row.className = 'log-entry';
+  const ts = document.createElement('span');
+  ts.className = 'ts';
+  ts.textContent = formatTimestamp(entry.ts);
+  const msg = document.createElement('span');
+  msg.textContent = entry.message || entry.msg || '';
+  row.appendChild(ts);
+  row.appendChild(msg);
+  logStream.appendChild(row);
+  logStream.scrollTop = logStream.scrollHeight;
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '';
+  const date = new Date(ts * 1000);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+async function triggerVideo(puzzleId) {
+  try {
+    await postJSON('/api/video', { game_id: puzzleId });
+  } catch (error) {
+    console.error('Failed to trigger video', error);
+  }
+}
+
+async function toggleSolved(puzzle) {
+  try {
+    await postJSON(`/api/puzzles/${puzzle.id}/solve`, { solved: !puzzle.solved });
+  } catch (error) {
+    console.error('Failed to update puzzle', error);
+  }
+}
+
+async function adjustHints(puzzle, delta) {
+  try {
+    await postJSON(`/api/puzzles/${puzzle.id}/hints`, { delta });
+  } catch (error) {
+    console.error('Failed to update hints', error);
+  }
+}
+
+async function sendTimerAction(action, value = null) {
+  try {
+    await postJSON('/api/timer/control', { action, value });
+  } catch (error) {
+    console.error('Timer action failed', error);
+  }
+}
+
+function parseTimeInput(value) {
+  if (!value) return null;
+  const parts = value.split(':').map((p) => p.trim());
+  if (parts.length === 3) {
+    const [h, m, s] = parts.map((p) => Number(p));
+    if ([h, m, s].some((n) => Number.isNaN(n))) return null;
+    return h * 3600 + m * 60 + s;
+  }
+  if (parts.length === 2) {
+    const [m, s] = parts.map((p) => Number(p));
+    if ([m, s].some((n) => Number.isNaN(n))) return null;
+    return m * 60 + s;
+  }
+  const asNumber = Number(value);
+  return Number.isNaN(asNumber) ? null : asNumber;
+}
+
+function getSelectedDevices() {
+  const selected = Array.from(deviceCheckboxes.querySelectorAll('input[type="checkbox"]:checked')).map((el) => el.value);
+  return selected;
+}
+
+async function sendClue() {
+  const textArea = document.getElementById('clue-text');
+  const text = textArea.value.trim();
+  if (!text) return;
+  const targets = getSelectedDevices();
+  try {
+    await postJSON('/api/messages', { text, targets });
+    textArea.value = '';
+  } catch (error) {
+    console.error('Failed to send message', error);
+  }
+}
+
+function attachEventHandlers() {
+  document.querySelectorAll('[data-action]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.action;
+      if (action === 'reset') {
+        sendTimerAction('reset', 0);
+      } else {
+        sendTimerAction(action);
+      }
+    });
+  });
+
+  document.querySelectorAll('[data-adjust]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const delta = Number(btn.dataset.adjust || '0');
+      sendTimerAction('add', delta);
+    });
+  });
+
+  document.getElementById('timer-set-btn').addEventListener('click', () => {
+    const inputValue = document.getElementById('timer-set').value.trim();
+    const seconds = parseTimeInput(inputValue);
+    if (seconds != null) {
+      sendTimerAction('set', seconds);
+    }
+  });
+
+  document.getElementById('send-clue-btn').addEventListener('click', sendClue);
+  document.getElementById('clear-log').addEventListener('click', () => {
+    state.log = [];
+    renderLog([]);
+  });
+}
+
+function applyState(data) {
+  state.rooms = data.rooms || {};
+  state.devices = data.devices || {};
+  state.puzzles = {};
+  (data.puzzles || []).forEach((p) => {
+    state.puzzles[p.id] = p;
+  });
+  state.log = data.log || [];
+  updateTimerDisplay(data.timer || '00:00:00', data.timer_running);
+  renderDevices(state.devices);
+  renderRooms();
+  renderLog(state.log);
+  if (data.mqtt_host) {
+    mqttHost.textContent = data.mqtt_host;
+  }
+}
+
+async function loadInitialState() {
+  try {
+    const data = await fetch('/api/state').then((res) => res.json());
+    applyState(data);
+  } catch (error) {
+    console.error('Failed to load state', error);
+  }
+}
+
+function handleSocketMessage(message) {
+  const { type, data } = message;
+  switch (type) {
+    case 'state':
+      applyState(data);
+      break;
+    case 'timer':
+      updateTimerDisplay(data.formatted, data.running);
+      break;
+    case 'puzzle':
+      state.puzzles[data.id] = data;
+      renderRooms();
+      break;
+    case 'log':
+      appendLog(data);
+      break;
+    default:
+      break;
+  }
+}
+
+function connectWebSocket() {
+  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const wsUrl = `${protocol}://${window.location.host}/ws`;
+  let reconnectDelay = 1000;
+
+  function establish() {
+    const ws = new WebSocket(wsUrl);
+    wsStatus.textContent = 'Connecting…';
+    wsStatus.className = 'badge rounded-pill bg-secondary';
+
+    ws.onopen = () => {
+      wsStatus.textContent = 'Connected';
+      wsStatus.className = 'badge rounded-pill bg-success';
+      reconnectDelay = 1000;
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        handleSocketMessage(payload);
+      } catch (error) {
+        console.error('Invalid WS payload', error);
+      }
+    };
+
+    ws.onclose = () => {
+      wsStatus.textContent = 'Disconnected';
+      wsStatus.className = 'badge rounded-pill bg-danger';
+      setTimeout(establish, reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 1.5, 10000);
+    };
+
+    ws.onerror = () => {
+      wsStatus.textContent = 'Error';
+      wsStatus.className = 'badge rounded-pill bg-danger';
+    };
+  }
+
+  establish();
+}
+
+attachEventHandlers();
+loadInitialState();
+connectWebSocket();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,160 @@
+:root {
+  --accent: #0ea5e9;
+  --bg-glass: rgba(20, 24, 32, 0.85);
+  --border-glass: rgba(148, 163, 184, 0.14);
+  --text-muted: #8b9cb2;
+  --font-body: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Courier New', monospace;
+}
+
+body {
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top, #0f172a 0%, #020617 60%, #000 100%);
+  color: #f8fafc;
+  min-height: 100vh;
+}
+
+.text-accent {
+  color: var(--accent) !important;
+}
+
+.card.glass {
+  background: var(--bg-glass);
+  border: 1px solid var(--border-glass);
+  border-radius: 18px;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(18px);
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.timer-display {
+  font-family: var(--font-mono);
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  letter-spacing: 0.2em;
+}
+
+.timer-input input {
+  font-family: var(--font-mono);
+}
+
+.status-pill-stack .badge {
+  font-family: var(--font-mono);
+}
+
+.log-stream {
+  font-family: var(--font-mono);
+  min-height: 260px;
+  max-height: 340px;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.log-entry {
+  font-size: 0.85rem;
+  margin-bottom: 0.35rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.log-entry .ts {
+  color: var(--text-muted);
+}
+
+.puzzle-card {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(12px);
+  padding: 1.25rem;
+}
+
+.puzzle-card h3 {
+  font-size: 1.15rem;
+  margin-bottom: 1rem;
+}
+
+.puzzle-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 0.4rem;
+}
+
+.puzzle-table tbody tr {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 12px;
+}
+
+.puzzle-table tbody tr td {
+  padding: 0.55rem 0.75rem;
+  vertical-align: middle;
+}
+
+.puzzle-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.badge-soft {
+  border-radius: 999px;
+  padding: 0.15rem 0.7rem;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.badge-soft.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+
+.badge-soft.danger {
+  background: rgba(248, 113, 113, 0.15);
+  color: #fca5a5;
+}
+
+.badge-soft.info {
+  background: rgba(14, 165, 233, 0.12);
+  color: #7dd3fc;
+}
+
+.device-pill {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.35rem 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  font-size: 0.85rem;
+}
+
+.device-pill input {
+  margin-right: 0.35rem;
+}
+
+.room-actions .btn {
+  border-radius: 999px;
+}
+
+@media (max-width: 767px) {
+  .timer-display {
+    letter-spacing: 0.08em;
+  }
+  .timer-input {
+    width: 100%;
+  }
+  .timer-input .btn {
+    min-width: 100px;
+  }
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Jigsaw Control Room</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;700&family=Manrope:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body class="bg-body text-body">
+    <div class="container-xxl py-4">
+      <header class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+        <div>
+          <h1 class="display-6 fw-bold text-accent mb-1">Jigsaw — Control Room</h1>
+          <div class="text-secondary small">Monitor every puzzle, send clues, and keep the experience flowing.</div>
+        </div>
+        <div class="status-pill-stack text-end small">
+          <div>WebSocket: <span id="ws-status" class="badge rounded-pill bg-secondary">Connecting…</span></div>
+          <div>MQTT Broker: <span id="mqtt-host" class="fw-semibold"></span></div>
+        </div>
+      </header>
+
+      <section class="row g-4 mb-4" id="timer-section">
+        <div class="col-12 col-xl-7">
+          <div class="card glass h-100">
+            <div class="card-body">
+              <div class="d-flex flex-wrap align-items-end justify-content-between gap-3">
+                <div>
+                  <div class="label">Current Timer</div>
+                  <div id="timer-display" class="timer-display">00:00:00</div>
+                  <div class="small text-secondary" id="timer-status">Idle</div>
+                </div>
+                <div class="text-end">
+                  <div class="label">Quick Adjust</div>
+                  <div class="btn-group btn-group-sm">
+                    <button class="btn btn-outline-light" data-adjust="-300">-5m</button>
+                    <button class="btn btn-outline-light" data-adjust="-60">-1m</button>
+                    <button class="btn btn-outline-light" data-adjust="60">+1m</button>
+                    <button class="btn btn-outline-light" data-adjust="300">+5m</button>
+                  </div>
+                </div>
+              </div>
+              <hr class="border-secondary-subtle" />
+              <div class="d-flex flex-wrap align-items-center gap-3">
+                <div class="btn-group btn-group-lg">
+                  <button class="btn btn-success" data-action="start">Start</button>
+                  <button class="btn btn-warning" data-action="pause">Pause</button>
+                  <button class="btn btn-outline-danger" data-action="reset">Reset</button>
+                </div>
+                <div class="input-group input-group-lg timer-input">
+                  <span class="input-group-text">Set</span>
+                  <input type="text" id="timer-set" class="form-control" placeholder="HH:MM:SS" />
+                  <button class="btn btn-primary" id="timer-set-btn">Apply</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-xl-5">
+          <div class="card glass h-100">
+            <div class="card-body d-flex flex-column">
+              <div class="label mb-2">Send text clue</div>
+              <div class="mb-3">
+                <textarea class="form-control clue-text" id="clue-text" rows="3" placeholder="Type your clue…"></textarea>
+              </div>
+              <div class="mb-3">
+                <div class="label mb-1">Send to</div>
+                <div id="device-checkboxes" class="d-flex flex-wrap gap-2"></div>
+              </div>
+              <div class="d-flex justify-content-between align-items-center mt-auto">
+                <div class="small text-secondary">Messages are logged in the timeline.</div>
+                <button class="btn btn-primary" id="send-clue-btn">Send clue</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="row g-4" id="rooms-section">
+        <div class="col-12">
+          <h2 class="h4 text-uppercase text-secondary">Rooms &amp; puzzles</h2>
+        </div>
+        <div id="rooms-container" class="col-12 d-grid gap-4"></div>
+      </section>
+
+      <section class="row g-4 mt-1">
+        <div class="col-12 col-lg-6">
+          <div class="card glass h-100">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <div class="label">Recent activity</div>
+                <button class="btn btn-sm btn-outline-light" id="clear-log">Clear</button>
+              </div>
+              <div id="log-stream" class="log-stream"></div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-lg-6">
+          <div class="card glass h-100">
+            <div class="card-body">
+              <div class="label mb-2">Notes</div>
+              <p class="text-secondary small mb-0">This interface is optimised for touch screens and dark control rooms. Use the puzzle actions to play videos, mark solves, and keep everyone in sync.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/pi_clients/README.md
+++ b/pi_clients/README.md
@@ -1,0 +1,44 @@
+# Raspberry Pi Clue Players
+
+Each Raspberry Pi in the experience listens to MQTT topics and either plays a video clue or shows a text message on its local display. This folder ships a lightweight client that you can run on every Pi.
+
+## Prerequisites
+
+- Copy the entire repository to the Pi.
+- Place the MP4 assets under the `assets/` directory, preserving the folder names (`boiler room`, `hol intrare`, etc.).
+- Install the Python dependencies (a small venv per Pi is recommended):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ..  # installs the shared project dependencies
+```
+
+`cvlc` must also be available for fullscreen playback (preinstalled on Raspberry Pi OS with VLC).
+
+## Running
+
+Use the `run_client.py` helper to start the correct profile. The client automatically reads the MQTT broker host/port from `app/config.py`, but you can override them via flags if needed.
+
+```bash
+python -m pi_clients.run_client boilerroom
+```
+
+Available device profiles:
+
+- `boilerroom` – covers Boiler Room and Small Room videos (topic prefix `boiler/…`).
+- `holintrare` – plays Hol Intrare and Hall Room videos (topic prefix `hall/…`).
+- `lastroom` – plays Jigsaw and Last Room videos (topic prefix `last/…`).
+
+To run the clients persistently, create a `systemd` service on each Pi that executes the command above inside its virtual environment. When the control UI triggers a clue, the Pi will immediately start VLC fullscreen; text clues fade automatically after 30 seconds.
+
+## Text overlay
+
+Text messages sent from the control room appear on a full-screen overlay with white text on a black background. Pressing `Esc` on the Pi keyboard will close the client in case you need to exit the kiosk view manually.
+
+## Customisation
+
+- Adjust the default video command by editing `VideoPlayer` in `pi_clients/common.py` (for example to use `omxplayer`).
+- Change the asset folder mapping in `pi_clients/device_profiles.py` if you relocate the media files.
+- To tweak message duration, update `TextOverlay.show()` or change the call in the MQTT handler.
+

--- a/pi_clients/common.py
+++ b/pi_clients/common.py
@@ -1,0 +1,205 @@
+"""Shared helpers for Raspberry Pi clue players."""
+from __future__ import annotations
+
+import logging
+import queue
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import paho.mqtt.client as mqtt
+import tkinter as tk
+import tkinter.font as tkfont
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MessageEvent:
+    text: str
+    duration: float
+
+
+class TextOverlay:
+    """Simple full-screen text display driven by a queue."""
+
+    def __init__(self, *, background: str = "black", foreground: str = "white") -> None:
+        self._queue: queue.Queue[MessageEvent | None] = queue.Queue()
+        self._root = tk.Tk()
+        self._root.attributes("-fullscreen", True)
+        self._root.configure(bg=background)
+        self._root.bind("<Escape>", lambda _: self._root.quit())
+        width = self._root.winfo_screenwidth()
+        base_font = tkfont.Font(family="Helvetica", size=max(48, width // 20), weight="bold")
+        self._label = tk.Label(
+            self._root,
+            text="",
+            fg=foreground,
+            bg=background,
+            font=base_font,
+            wraplength=width - 200,
+            justify="center",
+        )
+        self._label.pack(expand=True, fill="both", padx=40, pady=40)
+        self._hide_after: float | None = None
+        self._root.after(100, self._poll)
+
+    def show(self, text: str, duration: float = 30.0) -> None:
+        self._queue.put(MessageEvent(text=text, duration=duration))
+
+    def hide(self) -> None:
+        self._queue.put(None)
+
+    def shutdown(self) -> None:
+        """Exit the Tk main loop."""
+        try:
+            if self._root.winfo_exists():
+                self._root.quit()
+        except tk.TclError:  # pragma: no cover - teardown safety
+            pass
+
+    def run(self) -> None:
+        logger.info("Starting overlay loop")
+        self._root.mainloop()
+
+    def _poll(self) -> None:
+        try:
+            while True:
+                event = self._queue.get_nowait()
+                if event is None:
+                    logger.info("Clearing on-screen message")
+                    self._label.config(text="")
+                    self._hide_after = None
+                else:
+                    logger.info("Displaying message: %s", event.text)
+                    self._label.config(text=event.text)
+                    self._hide_after = time.time() + event.duration
+        except queue.Empty:
+            pass
+
+        if self._hide_after and time.time() >= self._hide_after:
+            logger.info("Message timeout reached, hiding")
+            self._label.config(text="")
+            self._hide_after = None
+
+        self._root.after(100, self._poll)
+
+
+class VideoPlayer:
+    """Launches fullscreen video playback with cvlc or omxplayer."""
+
+    def __init__(self, videos: Mapping[str, Path], *, command: Iterable[str] | None = None) -> None:
+        self._videos = videos
+        self._command = list(command) if command else ["cvlc", "--fullscreen", "--play-and-exit"]
+        self._process: subprocess.Popen[str] | None = None
+        self._lock = threading.Lock()
+
+    def play(self, video_id: str) -> None:
+        video_path = self._videos.get(video_id)
+        if not video_path:
+            logger.warning("Received unknown video id %s", video_id)
+            return
+        if not video_path.exists():
+            logger.error("Video file missing: %s", video_path)
+            return
+        with self._lock:
+            self.stop()
+            logger.info("Playing %s", video_path)
+            try:
+                self._process = subprocess.Popen([*self._command, str(video_path)])
+            except FileNotFoundError:
+                logger.exception("Video player command not found: %s", self._command[0])
+            except Exception:  # pragma: no cover - subprocess errors
+                logger.exception("Failed to start video player")
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._process and self._process.poll() is None:
+                logger.info("Stopping current video")
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+            self._process = None
+
+
+class PiClient:
+    """MQTT listener that bridges messages to local playback."""
+
+    def __init__(
+        self,
+        *,
+        device_key: str,
+        mqtt_prefix: str,
+        video_map: Mapping[str, Path],
+        mqtt_host: str | None = None,
+        mqtt_port: int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._mqtt_host = mqtt_host or settings.mqtt_host
+        self._mqtt_port = mqtt_port or settings.mqtt_port
+        self._prefix = mqtt_prefix.rstrip("/")
+        self._client = mqtt.Client(client_id=f"jigsaw-{device_key}")
+        self._player = VideoPlayer(video_map)
+        self._overlay = TextOverlay()
+        self._client.on_connect = self._on_connect
+        self._client.on_message = self._on_message
+        self._stopping = threading.Event()
+
+    def start(self) -> None:
+        logger.info("Connecting to MQTT at %s:%s", self._mqtt_host, self._mqtt_port)
+        self._client.connect(self._mqtt_host, self._mqtt_port, keepalive=60)
+        self._client.loop_start()
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        try:
+            self._overlay.run()
+        finally:
+            self.stop()
+
+    def stop(self) -> None:
+        if self._stopping.is_set():
+            return
+        self._stopping.set()
+        logger.info("Stopping Pi client")
+        self._player.stop()
+        self._overlay.shutdown()
+        try:
+            self._client.loop_stop()
+            self._client.disconnect()
+        except Exception:  # pragma: no cover - shutdown safety
+            logger.exception("Error while disconnecting MQTT client")
+
+    # MQTT callbacks -----------------------------------------------------
+
+    def _on_connect(self, client: mqtt.Client, userdata, flags, rc) -> None:  # pragma: no cover - callback
+        if rc != 0:
+            logger.error("MQTT connection failed with code %s", rc)
+            return
+        logger.info("Connected to MQTT broker")
+        client.subscribe(f"{self._prefix}/video/play")
+        client.subscribe(f"{self._prefix}/text/send")
+
+    def _on_message(self, client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:  # pragma: no cover - callback
+        topic = msg.topic
+        payload = msg.payload.decode(errors="ignore").strip()
+        logger.info("Received MQTT message on %s: %s", topic, payload)
+        if topic.endswith("/video/play"):
+            if payload:
+                self._player.play(payload)
+        elif topic.endswith("/text/send"):
+            if payload:
+                self._overlay.show(payload)
+            else:
+                self._overlay.hide()
+
+    def _handle_signal(self, signum, frame) -> None:  # pragma: no cover - signal handler
+        logger.info("Received signal %s, shutting down", signum)
+        self.stop()

--- a/pi_clients/device_profiles.py
+++ b/pi_clients/device_profiles.py
@@ -1,0 +1,62 @@
+"""Device-specific metadata for Raspberry Pi clue players."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Mapping
+
+from app.data import ROOM_GROUPS
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceProfile:
+    """Information required to run a clue player on a Raspberry Pi."""
+
+    key: str
+    label: str
+    mqtt_prefix: str
+    asset_root: Path
+    video_map: Mapping[str, Path]
+
+
+ASSETS_ROOT = Path(__file__).resolve().parents[1] / "assets"
+
+ROOM_FOLDERS: Dict[str, str] = {
+    "Boiler Room": "boiler room",
+    "Small Room": "small room",
+    "Hall Room": "hall room",
+    "Hol Intrare": "hol intrare",
+    "Jigsaw Room": "jigsaw room",
+    "Last Room": "last room",
+}
+
+
+def _build_video_map(device_key: str) -> Mapping[str, Path]:
+    mapping: Dict[str, Path] = {}
+    for room_key, room_data in ROOM_GROUPS.items():
+        room_label = room_data["label"]
+        folder = ROOM_FOLDERS.get(room_label)
+        if not folder:
+            continue
+        base_dir = ASSETS_ROOT / folder
+        for game in room_data["games"]:
+            if device_key in game.default_targets:
+                mapping[game.id] = base_dir / game.video
+    return mapping
+
+
+def get_device_profiles() -> Dict[str, DeviceProfile]:
+    profiles: Dict[str, DeviceProfile] = {}
+    for key, device in (
+        ("boilerroom", {"label": "Boiler Room", "prefix": "boiler"}),
+        ("holintrare", {"label": "Hol Intrare", "prefix": "hall"}),
+        ("lastroom", {"label": "Last Room", "prefix": "last"}),
+    ):
+        profiles[key] = DeviceProfile(
+            key=key,
+            label=device["label"],
+            mqtt_prefix=device["prefix"],
+            asset_root=ASSETS_ROOT,
+            video_map=_build_video_map(key),
+        )
+    return profiles

--- a/pi_clients/run_client.py
+++ b/pi_clients/run_client.py
@@ -1,0 +1,45 @@
+"""Command line entry point to launch a clue player on a Raspberry Pi."""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .common import PiClient
+from .device_profiles import get_device_profiles
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a Jigsaw clue player")
+    parser.add_argument(
+        "device",
+        choices=sorted(get_device_profiles().keys()),
+        help="Which device profile to run (boilerroom, holintrare, lastroom)",
+    )
+    parser.add_argument("--mqtt-host", dest="mqtt_host", help="Override MQTT host")
+    parser.add_argument("--mqtt-port", dest="mqtt_port", type=int, help="Override MQTT port")
+    parser.add_argument("--log-level", default="INFO", help="Python logging level")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format=LOG_FORMAT)
+    profiles = get_device_profiles()
+    profile = profiles[args.device]
+
+    client = PiClient(
+        device_key=profile.key,
+        mqtt_prefix=profile.mqtt_prefix,
+        video_map=profile.video_map,
+        mqtt_host=args.mqtt_host,
+        mqtt_port=args.mqtt_port,
+    )
+
+    client.start()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "jigsaw-clues"
+version = "0.1.0"
+description = "Control interface for the Jigsaw escape room system"
+requires-python = ">=3.10"
+authors = [{name = "Escape Control"}]
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "paho-mqtt>=1.6",
+    "pydantic>=2.6",
+    "python-dotenv>=1.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "httpx>=0.27",
+    "pytest>=7.4"
+]
+
+[tool.uvicorn]
+factory = "app.main:create_app"
+port = 8000
+host = "0.0.0.0"
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a reusable Raspberry Pi MQTT client with fullscreen text overlay and VLC video playback
- derive per-room device profiles from the existing puzzle catalogue and expose a CLI runner
- document how to deploy the control interface and per-room players on their respective Pis

## Testing
- python -m compileall app pi_clients

------
https://chatgpt.com/codex/tasks/task_e_68e633a816f08333968050749a0317dd